### PR TITLE
feat: Add iOS only enableMinificationFilter prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ Headers to load the image with. e.g. `{ Authorization: 'someAuthToken' }`.
 
 ---
 
+### `enableMinificationFilter?: boolean`
+iOS only props, if true will use to `kCAFilterTrilinear` as the minification filter, otherwise will use `kCAFilterLinear`.
+
+---
+
 ### `onLoadStart?: () => void`
 
 Called when the image starts to load.

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -10,14 +10,14 @@
 
 @interface FFFastImageView : SDAnimatedImageView
 
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageLoadStart;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageProgress;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageError;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageLoad;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageLoadEnd;
-@property (nonatomic, assign) RCTResizeMode resizeMode;
-@property (nonatomic, strong) FFFastImageSource *source;
-@property (nonatomic, strong) UIColor *imageColor;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageLoadStart;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageProgress;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageError;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageLoad;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageLoadEnd;
+@property(nonatomic, assign) RCTResizeMode resizeMode;
+@property(nonatomic, assign) BOOL minificationFilter;
+@property(nonatomic, strong) FFFastImageSource *source;
+@property(nonatomic, strong) UIColor *imageColor;
 
 @end
-

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -23,6 +23,18 @@
     return self;
 }
 
+- (void)setMinificationFilter:(BOOL)minificationFilter {
+    if (_minificationFilter != minificationFilter) {
+        _minificationFilter = minificationFilter;
+
+        if(minificationFilter == TRUE){
+            self.layer.minificationFilter = kCAFilterTrilinear;
+        }else{
+            self.layer.minificationFilter = kCAFilterLinear;
+        }
+    }
+}
+
 - (void)setResizeMode:(RCTResizeMode)resizeMode {
     if (_resizeMode != resizeMode) {
         _resizeMode = resizeMode;
@@ -137,13 +149,13 @@
             }
             self.hasCompleted = YES;
             [self sendOnLoad:image];
-            
+
             if (self.onFastImageLoadEnd) {
                 self.onFastImageLoadEnd(@{});
             }
             return;
         }
-        
+
         // Set headers.
         NSDictionary *headers = _source.headers;
         SDWebImageDownloaderRequestModifier *requestModifier = [SDWebImageDownloaderRequestModifier requestModifierWithBlock:^NSURLRequest * _Nullable(NSURLRequest * _Nonnull request) {
@@ -155,7 +167,7 @@
             return [mutableRequest copy];
         }];
         SDWebImageContext *context = @{SDWebImageContextDownloadRequestModifier : requestModifier};
-        
+
         // Set priority.
         SDWebImageOptions options = SDWebImageRetryFailed | SDWebImageHandleCookies;
         switch (_source.priority) {
@@ -169,7 +181,7 @@
                 options |= SDWebImageHighPriority;
                 break;
         }
-        
+
         switch (_source.cacheControl) {
             case FFFCacheControlWeb:
                 options |= SDWebImageRefreshCached;
@@ -180,7 +192,7 @@
             case FFFCacheControlImmutable:
                 break;
         }
-        
+
         if (self.onFastImageLoadStart) {
             self.onFastImageLoadStart(@{});
             self.hasSentOnLoadStart = YES;
@@ -189,7 +201,7 @@
         }
         self.hasCompleted = NO;
         self.hasErrored = NO;
-        
+
         [self downloadImage:_source options:options context:context];
     }
 }

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -19,6 +19,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
+RCT_REMAP_VIEW_PROPERTY(enableMinificationFilter, minificationFilter, BOOL)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -59,6 +59,7 @@ export type FastImageProps = $ReadOnly<{|
     source: FastImageSource | number,
 
     resizeMode?: ?ResizeModes,
+    enableMinificationFilter?: ?boolean,
     fallback?: ?boolean,
     testID?: ?string,
 |}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,6 +83,7 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
 export interface FastImageProps extends AccessibilityProps, ViewProps {
     source: Source | number
     resizeMode?: ResizeMode
+    enableMinificationFilter?: boolean
     fallback?: boolean
 
     onLoadStart?(): void


### PR DESCRIPTION
As reported in https://github.com/DylanVann/react-native-fast-image/issues/445 and on other issues when rendering larger images in small views using FastImage the image becomes pixilated.

The main idea for this is that by adding an iOS-only prop called `enableMinificationFilter` to FastImage we can switch between the default `minificationFilter` `kCAFilterLinear` and `kCAFilterTrilinear`, each of these gives a different look to the final image when downscaling it. E.g.

![test-comparison](https://user-images.githubusercontent.com/11707729/182468374-5f154376-1683-48b7-8fa8-fda7cff4e4e3.png)

The icon on the left uses kCAFilterTrilinear and the circle on the right uses kCAFilterLinear. You can find more information about Scaling Filters [here](https://developer.apple.com/documentation/quartzcore/calayer/scaling_filters?language=objc).

`minificationFilter` supports a variety of filters to be applied but for the sake of simplicity and based on the react native uses for their own Image component ([RCTImageView](https://github.com/facebook/react-native/blob/16397e0d3c0dd3374ddb642599725ca41f092a8a/Libraries/Image/RCTImageView.mm#L141-L143)) I opted for only allowing switching between `kCAFilterLinear` and `kCAFilterTrilinear`.



<details>
  <summary>Here's is the patch for these changes if you need this in your project while this does not get merged </summary>
  
  ## Patch
  1. Setup patch-package (More info [here](https://github.com/ds300/patch-package))
  2. Create a file called `react-native-fast-image+8.5.11.patch` under your patches folder
  3. Add the code bellow to your file
 


```patch
diff --git a/node_modules/react-native-fast-image/RNFastImage.podspec b/node_modules/react-native-fast-image/RNFastImage.podspec
index db0fada..47dbd5b 100644
--- a/node_modules/react-native-fast-image/RNFastImage.podspec
+++ b/node_modules/react-native-fast-image/RNFastImage.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React-Core'
-  s.dependency 'SDWebImage', '~> 5.11.1'
+  s.dependency 'SDWebImage', '~> 5.12.1'
   s.dependency 'SDWebImageWebPCoder', '~> 0.8.4'
 end
diff --git a/node_modules/react-native-fast-image/dist/index.d.ts b/node_modules/react-native-fast-image/dist/index.d.ts
index 8a91257..539aac6 100644
--- a/node_modules/react-native-fast-image/dist/index.d.ts
+++ b/node_modules/react-native-fast-image/dist/index.d.ts
@@ -56,6 +56,7 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
 export interface FastImageProps extends AccessibilityProps, ViewProps {
     source: Source | number;
     resizeMode?: ResizeMode;
+    enableMinificationFilter?:boolean;
     fallback?: boolean;
     onLoadStart?(): void;
     onProgress?(event: OnProgressEvent): void;
diff --git a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.h b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.h
index fb557cf..77e0b7d 100644
--- a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.h
+++ b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.h
@@ -10,14 +10,14 @@
 
 @interface FFFastImageView : SDAnimatedImageView
 
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageLoadStart;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageProgress;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageError;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageLoad;
-@property (nonatomic, copy) RCTDirectEventBlock onFastImageLoadEnd;
-@property (nonatomic, assign) RCTResizeMode resizeMode;
-@property (nonatomic, strong) FFFastImageSource *source;
-@property (nonatomic, strong) UIColor *imageColor;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageLoadStart;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageProgress;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageError;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageLoad;
+@property(nonatomic, copy) RCTDirectEventBlock onFastImageLoadEnd;
+@property(nonatomic, assign) RCTResizeMode resizeMode;
+@property(nonatomic, assign) BOOL minificationFilter;
+@property(nonatomic, strong) FFFastImageSource *source;
+@property(nonatomic, strong) UIColor *imageColor;
 
 @end
-
diff --git a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
index 9c0f1d3..cc1b1b9 100644
--- a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
+++ b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
@@ -23,6 +23,18 @@
     return self;
 }
 
+- (void)setMinificationFilter:(BOOL)minificationFilter {
+    if (_minificationFilter != minificationFilter) {
+        _minificationFilter = minificationFilter;
+
+        if(minificationFilter == TRUE){
+            self.layer.minificationFilter = kCAFilterTrilinear;
+        }else{
+            self.layer.minificationFilter = kCAFilterLinear;
+        }
+    }
+}
+
 - (void)setResizeMode:(RCTResizeMode)resizeMode {
     if (_resizeMode != resizeMode) {
         _resizeMode = resizeMode;
diff --git a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageViewManager.m b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageViewManager.m
index a8059af..5c3a447 100644
--- a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageViewManager.m
+++ b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageViewManager.m
@@ -19,6 +19,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
+RCT_REMAP_VIEW_PROPERTY(enableMinificationFilter, minificationFilter, BOOL)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)

```
</details>